### PR TITLE
- Fix: block/unblock feature did similar whatApp

### DIFF
--- a/.idea/AndroidProjectSystem.xml
+++ b/.idea/AndroidProjectSystem.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="AndroidProjectSystem">
+    <option name="providerId" value="com.android.tools.idea.GradleProjectSystem" />
+  </component>
+</project>

--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -4,6 +4,14 @@
     <selectionStates>
       <SelectionState runConfigName="app">
         <option name="selectionMode" value="DROPDOWN" />
+        <DropdownSelection timestamp="2026-06-17T14:16:16.228818900Z">
+          <Target type="DEFAULT_BOOT">
+            <handle>
+              <DeviceId pluginId="PhysicalDevice" identifier="serial=19041FDF6007D0" />
+            </handle>
+          </Target>
+        </DropdownSelection>
+        <DialogSelection />
       </SelectionState>
     </selectionStates>
   </component>

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -1,10 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="GradleMigrationSettings" migrationVersion="1" />
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
+        <option name="testRunner" value="CHOOSE_PER_TEST" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
-        <option name="gradleJvm" value="#GRADLE_LOCAL_JAVA_HOME" />
+        <option name="gradleJvm" value="corretto-17 (2)" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />
@@ -12,7 +14,6 @@
             <option value="$PROJECT_DIR$/isometrik-chat" />
           </set>
         </option>
-        <option name="resolveExternalAnnotations" value="false" />
       </GradleProjectSettings>
     </option>
   </component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,10 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="jbr-17" project-jdk-type="JavaSDK">
-    <output url="file://$PROJECT_DIR$/build/classes" />
-  </component>
-  <component name="ProjectType">
-    <option name="id" value="Android" />
-  </component>
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="corretto-17" project-jdk-type="JavaSDK" />
 </project>

--- a/.idea/runConfigurations.xml
+++ b/.idea/runConfigurations.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="RunConfigurationProducerService">
+    <option name="ignoredProducers">
+      <set>
+        <option value="com.intellij.execution.junit.AbstractAllInDirectoryConfigurationProducer" />
+        <option value="com.intellij.execution.junit.AllInPackageConfigurationProducer" />
+        <option value="com.intellij.execution.junit.PatternConfigurationProducer" />
+        <option value="com.intellij.execution.junit.TestInClassConfigurationProducer" />
+        <option value="com.intellij.execution.junit.UniqueIdConfigurationProducer" />
+        <option value="com.intellij.execution.junit.testDiscovery.JUnitTestDiscoveryConfigurationProducer" />
+        <option value="org.jetbrains.kotlin.idea.junit.KotlinJUnitRunConfigurationProducer" />
+        <option value="org.jetbrains.kotlin.idea.junit.KotlinPatternConfigurationProducer" />
+      </set>
+    </option>
+  </component>
+</project>

--- a/.idea/shelf/Uncommitted_changes_before_rebase_[Changes]/shelved.patch
+++ b/.idea/shelf/Uncommitted_changes_before_rebase_[Changes]/shelved.patch
@@ -1,0 +1,123 @@
+Index: .idea/migrations.xml
+===================================================================
+diff --git a/.idea/migrations.xml b/.idea/migrations.xml
+deleted file mode 100644
+--- a/.idea/migrations.xml	(revision 573f76b699d9a7523b563b21d0fb7a333dc69ba4)
++++ /dev/null	(revision 573f76b699d9a7523b563b21d0fb7a333dc69ba4)
+@@ -1,10 +0,0 @@
+-<?xml version="1.0" encoding="UTF-8"?>
+-<project version="4">
+-  <component name="ProjectMigrations">
+-    <option name="MigrateToGradleLocalJavaHome">
+-      <set>
+-        <option value="$PROJECT_DIR$" />
+-      </set>
+-    </option>
+-  </component>
+-</project>
+\ No newline at end of file
+Index: .idea/vcs.xml
+===================================================================
+diff --git a/.idea/vcs.xml b/.idea/vcs.xml
+deleted file mode 100644
+--- a/.idea/vcs.xml	(revision 573f76b699d9a7523b563b21d0fb7a333dc69ba4)
++++ /dev/null	(revision 573f76b699d9a7523b563b21d0fb7a333dc69ba4)
+@@ -1,6 +0,0 @@
+-<?xml version="1.0" encoding="UTF-8"?>
+-<project version="4">
+-  <component name="VcsDirectoryMappings">
+-    <mapping directory="" vcs="Git" />
+-  </component>
+-</project>
+\ No newline at end of file
+Index: .idea/kotlinc.xml
+===================================================================
+diff --git a/.idea/kotlinc.xml b/.idea/kotlinc.xml
+deleted file mode 100644
+--- a/.idea/kotlinc.xml	(revision 573f76b699d9a7523b563b21d0fb7a333dc69ba4)
++++ /dev/null	(revision 573f76b699d9a7523b563b21d0fb7a333dc69ba4)
+@@ -1,6 +0,0 @@
+-<?xml version="1.0" encoding="UTF-8"?>
+-<project version="4">
+-  <component name="KotlinJpsPluginSettings">
+-    <option name="version" value="1.9.23" />
+-  </component>
+-</project>
+\ No newline at end of file
+Index: .idea/deploymentTargetSelector.xml
+===================================================================
+diff --git a/.idea/deploymentTargetSelector.xml b/.idea/deploymentTargetSelector.xml
+deleted file mode 100644
+--- a/.idea/deploymentTargetSelector.xml	(revision 573f76b699d9a7523b563b21d0fb7a333dc69ba4)
++++ /dev/null	(revision 573f76b699d9a7523b563b21d0fb7a333dc69ba4)
+@@ -1,10 +0,0 @@
+-<?xml version="1.0" encoding="UTF-8"?>
+-<project version="4">
+-  <component name="deploymentTargetSelector">
+-    <selectionStates>
+-      <SelectionState runConfigName="app">
+-        <option name="selectionMode" value="DROPDOWN" />
+-      </SelectionState>
+-    </selectionStates>
+-  </component>
+-</project>
+\ No newline at end of file
+Index: .idea/compiler.xml
+===================================================================
+diff --git a/.idea/compiler.xml b/.idea/compiler.xml
+deleted file mode 100644
+--- a/.idea/compiler.xml	(revision 573f76b699d9a7523b563b21d0fb7a333dc69ba4)
++++ /dev/null	(revision 573f76b699d9a7523b563b21d0fb7a333dc69ba4)
+@@ -1,6 +0,0 @@
+-<?xml version="1.0" encoding="UTF-8"?>
+-<project version="4">
+-  <component name="CompilerConfiguration">
+-    <bytecodeTargetLevel target="17" />
+-  </component>
+-</project>
+\ No newline at end of file
+Index: .idea/misc.xml
+===================================================================
+diff --git a/.idea/misc.xml b/.idea/misc.xml
+deleted file mode 100644
+--- a/.idea/misc.xml	(revision 573f76b699d9a7523b563b21d0fb7a333dc69ba4)
++++ /dev/null	(revision 573f76b699d9a7523b563b21d0fb7a333dc69ba4)
+@@ -1,10 +0,0 @@
+-<?xml version="1.0" encoding="UTF-8"?>
+-<project version="4">
+-  <component name="ExternalStorageConfigurationManager" enabled="true" />
+-  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="jbr-17" project-jdk-type="JavaSDK">
+-    <output url="file://$PROJECT_DIR$/build/classes" />
+-  </component>
+-  <component name="ProjectType">
+-    <option name="id" value="Android" />
+-  </component>
+-</project>
+\ No newline at end of file
+Index: .idea/gradle.xml
+===================================================================
+diff --git a/.idea/gradle.xml b/.idea/gradle.xml
+deleted file mode 100644
+--- a/.idea/gradle.xml	(revision 573f76b699d9a7523b563b21d0fb7a333dc69ba4)
++++ /dev/null	(revision 573f76b699d9a7523b563b21d0fb7a333dc69ba4)
+@@ -1,19 +0,0 @@
+-<?xml version="1.0" encoding="UTF-8"?>
+-<project version="4">
+-  <component name="GradleSettings">
+-    <option name="linkedExternalProjectsSettings">
+-      <GradleProjectSettings>
+-        <option name="externalProjectPath" value="$PROJECT_DIR$" />
+-        <option name="gradleJvm" value="#GRADLE_LOCAL_JAVA_HOME" />
+-        <option name="modules">
+-          <set>
+-            <option value="$PROJECT_DIR$" />
+-            <option value="$PROJECT_DIR$/app" />
+-            <option value="$PROJECT_DIR$/isometrik-chat" />
+-          </set>
+-        </option>
+-        <option name="resolveExternalAnnotations" value="false" />
+-      </GradleProjectSettings>
+-    </option>
+-  </component>
+-</project>
+\ No newline at end of file

--- a/.idea/shelf/Uncommitted_changes_before_rebase__Changes_.xml
+++ b/.idea/shelf/Uncommitted_changes_before_rebase__Changes_.xml
@@ -1,0 +1,7 @@
+<changelist name="Uncommitted_changes_before_rebase_[Changes]" date="1781706561238" recycled="true" deleted="true">
+  <option name="PATH" value="$PROJECT_DIR$/.idea/shelf/Uncommitted_changes_before_rebase_[Changes]/shelved.patch" />
+  <option name="DESCRIPTION" value="Uncommitted changes before rebase [Changes]" />
+  <binary>
+    <option name="BEFORE_PATH" value=".idea/.name" />
+  </binary>
+</changelist>

--- a/isometrik-chat/src/main/java/io/isometrik/chat/response/message/utils/fetchmessages/Message.java
+++ b/isometrik-chat/src/main/java/io/isometrik/chat/response/message/utils/fetchmessages/Message.java
@@ -168,6 +168,12 @@ public class Message {
   @SerializedName("opponentProfileImageUrl")
   @Expose
   private String opponentProfileImageUrl;
+  @SerializedName("callDurations")
+  @Expose
+  private Object callDurations;
+  @SerializedName("missedByMembers")
+  @Expose
+  private Object missedByMembers;
 
   /**
    * Gets notification.
@@ -643,5 +649,23 @@ public class Message {
    */
   public Boolean getMessageUpdated() {
     return messageUpdated;
+  }
+
+  /**
+   * Gets call durations (top-level in API response for call end messages).
+   *
+   * @return the call durations as Object (List/array from JSON)
+   */
+  public Object getCallDurations() {
+    return callDurations;
+  }
+
+  /**
+   * Gets missed by members (top-level in API response for call end messages).
+   *
+   * @return the missed by members as Object (List/array from JSON)
+   */
+  public Object getMissedByMembers() {
+    return missedByMembers;
   }
 }

--- a/isometrik-chat/src/main/java/io/isometrik/chat/utils/BlockStateCache.java
+++ b/isometrik-chat/src/main/java/io/isometrik/chat/utils/BlockStateCache.java
@@ -1,0 +1,140 @@
+package io.isometrik.chat.utils;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import androidx.annotation.Nullable;
+import io.isometrik.ui.IsometrikChatSdk;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Persists block direction per opponent when list API returns messagingDisabled=true
+ * without metaData.blockedMessage (backend inconsistency).
+ */
+public final class BlockStateCache {
+
+  private static final String PREFS_NAME = "IsometrikBlockState";
+  private static final String KEY_PREFIX_OPPONENT = "opponent:";
+  private static final String KEY_PREFIX_CONVERSATION = "conversation:";
+
+  private static final ConcurrentHashMap<String, Boolean> blockedByOpponentByOpponentId =
+      new ConcurrentHashMap<>();
+  private static final ConcurrentHashMap<String, Boolean> blockedByOpponentByConversationId =
+      new ConcurrentHashMap<>();
+
+  private BlockStateCache() {
+  }
+
+  public static void setBlockedByOpponent(String opponentUserId, boolean blockedByOpponent) {
+    if (opponentUserId == null || opponentUserId.isEmpty()) {
+      return;
+    }
+    blockedByOpponentByOpponentId.put(opponentUserId, blockedByOpponent);
+    persistOpponent(opponentUserId, blockedByOpponent);
+    BlockStatusUtil.log("BlockStateCache",
+        "set opponentUserId=" + opponentUserId + " blockedByOpponent=" + blockedByOpponent);
+  }
+
+  public static void setBlockedByOpponentForConversation(String conversationId,
+      String opponentUserId, boolean blockedByOpponent) {
+    setBlockedByOpponent(opponentUserId, blockedByOpponent);
+    if (conversationId != null && !conversationId.isEmpty()) {
+      blockedByOpponentByConversationId.put(conversationId, blockedByOpponent);
+      persistConversation(conversationId, blockedByOpponent);
+      BlockStatusUtil.log("BlockStateCache",
+          "set conversationId=" + conversationId + " blockedByOpponent=" + blockedByOpponent);
+    }
+  }
+
+  @Nullable
+  public static Boolean getBlockedByOpponent(String opponentUserId) {
+    if (opponentUserId == null || opponentUserId.isEmpty()) {
+      return null;
+    }
+    Boolean inMemory = blockedByOpponentByOpponentId.get(opponentUserId);
+    if (inMemory != null) {
+      return inMemory;
+    }
+    return readPersistedOpponent(opponentUserId);
+  }
+
+  @Nullable
+  public static Boolean getBlockedByOpponentForConversation(String conversationId) {
+    if (conversationId == null || conversationId.isEmpty()) {
+      return null;
+    }
+    Boolean inMemory = blockedByOpponentByConversationId.get(conversationId);
+    if (inMemory != null) {
+      return inMemory;
+    }
+    return readPersistedConversation(conversationId);
+  }
+
+  public static void clear(String opponentUserId) {
+    if (opponentUserId != null && !opponentUserId.isEmpty()) {
+      blockedByOpponentByOpponentId.remove(opponentUserId);
+      removePersisted(KEY_PREFIX_OPPONENT + opponentUserId);
+      BlockStatusUtil.log("BlockStateCache", "cleared opponentUserId=" + opponentUserId);
+    }
+  }
+
+  public static void clearConversation(String conversationId, String opponentUserId) {
+    clear(opponentUserId);
+    if (conversationId != null && !conversationId.isEmpty()) {
+      blockedByOpponentByConversationId.remove(conversationId);
+      removePersisted(KEY_PREFIX_CONVERSATION + conversationId);
+      BlockStatusUtil.log("BlockStateCache", "cleared conversationId=" + conversationId);
+    }
+  }
+
+  private static SharedPreferences prefs() {
+    Context context = IsometrikChatSdk.getInstance().getContext();
+    return context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE);
+  }
+
+  private static String scopedUserKey(String suffix) {
+    String userId = IsometrikChatSdk.getInstance().getUserSession().getUserId();
+    return userId + ":" + suffix;
+  }
+
+  private static void persistOpponent(String opponentUserId, boolean blockedByOpponent) {
+    prefs().edit()
+        .putBoolean(scopedUserKey(KEY_PREFIX_OPPONENT + opponentUserId), blockedByOpponent)
+        .apply();
+  }
+
+  private static void persistConversation(String conversationId, boolean blockedByOpponent) {
+    prefs().edit()
+        .putBoolean(scopedUserKey(KEY_PREFIX_CONVERSATION + conversationId), blockedByOpponent)
+        .apply();
+  }
+
+  @Nullable
+  private static Boolean readPersistedOpponent(String opponentUserId) {
+    String key = scopedUserKey(KEY_PREFIX_OPPONENT + opponentUserId);
+    if (!prefs().contains(key)) {
+      return null;
+    }
+    boolean value = prefs().getBoolean(key, false);
+    blockedByOpponentByOpponentId.put(opponentUserId, value);
+    BlockStatusUtil.log("BlockStateCache",
+        "restored from disk opponentUserId=" + opponentUserId + " blockedByOpponent=" + value);
+    return value;
+  }
+
+  @Nullable
+  private static Boolean readPersistedConversation(String conversationId) {
+    String key = scopedUserKey(KEY_PREFIX_CONVERSATION + conversationId);
+    if (!prefs().contains(key)) {
+      return null;
+    }
+    boolean value = prefs().getBoolean(key, false);
+    blockedByOpponentByConversationId.put(conversationId, value);
+    BlockStatusUtil.log("BlockStateCache",
+        "restored from disk conversationId=" + conversationId + " blockedByOpponent=" + value);
+    return value;
+  }
+
+  private static void removePersisted(String suffix) {
+    prefs().edit().remove(scopedUserKey(suffix)).apply();
+  }
+}

--- a/isometrik-chat/src/main/java/io/isometrik/chat/utils/BlockStatusUtil.java
+++ b/isometrik-chat/src/main/java/io/isometrik/chat/utils/BlockStatusUtil.java
@@ -1,0 +1,212 @@
+package io.isometrik.chat.utils;
+
+import android.util.Log;
+import androidx.annotation.Nullable;
+import org.json.JSONObject;
+
+/**
+ * Parses block state from conversation API metadata and logs with a single debug tag.
+ */
+public final class BlockStatusUtil {
+
+  public static final String TAG = "ISOMETRIK_BLOCK";
+
+  private BlockStatusUtil() {
+  }
+
+  public static void log(String message) {
+    Log.d(TAG, message);
+  }
+
+  public static void log(String source, String message) {
+    Log.d(TAG, source + " -> " + message);
+  }
+
+  /**
+   * @return true if opponent blocked current user, false if current user blocked opponent,
+   *         null if block state could not be determined from metadata.
+   */
+  @Nullable
+  public static Boolean parseBlockedByOpponent(@Nullable JSONObject metaData, @Nullable String opponentUserId,
+      @Nullable String currentUserId, @Nullable String source) {
+    log(source, "parseBlockedByOpponent opponentUserId=" + opponentUserId
+        + " currentUserId=" + currentUserId
+        + " metaData=" + (metaData != null ? metaData.toString() : "null"));
+
+    if (metaData == null) {
+      log(source, "metaData is null, cannot parse block state");
+      return null;
+    }
+
+    try {
+      JSONObject blockedMessage = extractBlockedMessage(metaData);
+      if (blockedMessage == null) {
+        log(source, "blockedMessage not found in metaData");
+        return null;
+      }
+
+      log(source, "blockedMessage=" + blockedMessage);
+
+      if (blockedMessage.has("sentByMe")) {
+        boolean sentByMe = readBoolean(blockedMessage, "sentByMe");
+        boolean blockedByOpponent = !sentByMe;
+        log(source, "resolved via sentByMe=" + sentByMe + " blockedByOpponent=" + blockedByOpponent);
+        return blockedByOpponent;
+      }
+
+      String initiatorId = blockedMessage.optString("initiatorId", null);
+      if (initiatorId == null || initiatorId.isEmpty()) {
+        initiatorId = blockedMessage.optString("userId", null);
+      }
+
+      if (initiatorId != null && !initiatorId.isEmpty()) {
+        if (currentUserId != null && initiatorId.equals(currentUserId)) {
+          log(source, "resolved via initiatorId=currentUser (I blocked) -> false");
+          return false;
+        }
+        if (opponentUserId != null && initiatorId.equals(opponentUserId)) {
+          log(source, "resolved via initiatorId=opponentUserId (blocked by opponent) -> true");
+          return true;
+        }
+        log(source, "initiatorId present but does not match current or opponent user");
+      }
+    } catch (Exception e) {
+      log(source, "parse error: " + e.getMessage());
+    }
+
+    return null;
+  }
+
+  /**
+   * Parse block state from conversation lastMessage when metaData is empty on list API.
+   */
+  @Nullable
+  public static Boolean parseBlockedByOpponentFromLastMessage(@Nullable JSONObject lastMessage,
+      @Nullable String opponentUserId, @Nullable String currentUserId, @Nullable String source) {
+    if (lastMessage == null) {
+      log(source, "lastMessage is null");
+      return null;
+    }
+
+    log(source, "parseFromLastMessage lastMessage=" + lastMessage);
+
+    try {
+      String action = lastMessage.optString("action", null);
+      String customType = lastMessage.optString("customType", null);
+
+      if (!"userBlockConversation".equals(action) && !"block".equals(customType)) {
+        log(source, "lastMessage is not a block action (action=" + action + " customType=" + customType + ")");
+        return null;
+      }
+
+      if (lastMessage.has("sentByMe")) {
+        boolean sentByMe = readBoolean(lastMessage, "sentByMe");
+        boolean blockedByOpponent = !sentByMe;
+        log(source, "lastMessage resolved via sentByMe=" + sentByMe + " blockedByOpponent=" + blockedByOpponent);
+        return blockedByOpponent;
+      }
+
+      String initiatorId = lastMessage.optString("initiatorId", null);
+      if (initiatorId == null || initiatorId.isEmpty()) {
+        initiatorId = lastMessage.optString("userId", null);
+      }
+      if (initiatorId != null && !initiatorId.isEmpty()) {
+        if (currentUserId != null && initiatorId.equals(currentUserId)) {
+          log(source, "lastMessage resolved via initiatorId=currentUser -> false");
+          return false;
+        }
+        if (opponentUserId != null && initiatorId.equals(opponentUserId)) {
+          log(source, "lastMessage resolved via initiatorId=opponentUserId -> true");
+          return true;
+        }
+      }
+
+      String initiatorName = lastMessage.optString("initiatorName", null);
+      String opponentName = lastMessage.optString("opponentName", null);
+      String currentUserName = io.isometrik.ui.IsometrikChatSdk.getInstance().getUserSession().getUserName();
+      if (opponentName != null && opponentName.equals(currentUserName)) {
+        log(source, "lastMessage resolved via opponentName=currentUser -> true");
+        return true;
+      }
+      if (initiatorName != null && initiatorName.equals(currentUserName)) {
+        log(source, "lastMessage resolved via initiatorName=currentUser -> false");
+        return false;
+      }
+    } catch (Exception e) {
+      log(source, "lastMessage parse error: " + e.getMessage());
+    }
+
+    return null;
+  }
+
+  /**
+   * Resolve block state using metadata, lastMessage, then session cache (MQTT).
+   */
+  @Nullable
+  public static Boolean resolveBlockedByOpponent(@Nullable JSONObject metaData,
+      @Nullable JSONObject lastMessage, @Nullable String opponentUserId,
+      @Nullable String currentUserId, boolean messagingDisabled, @Nullable String source) {
+    return resolveBlockedByOpponent(metaData, lastMessage, null, opponentUserId, currentUserId,
+        messagingDisabled, source);
+  }
+
+  @Nullable
+  public static Boolean resolveBlockedByOpponent(@Nullable JSONObject metaData,
+      @Nullable JSONObject lastMessage, @Nullable String conversationId,
+      @Nullable String opponentUserId, @Nullable String currentUserId, boolean messagingDisabled,
+      @Nullable String source) {
+    Boolean fromMeta = parseBlockedByOpponent(metaData, opponentUserId, currentUserId, source + "#meta");
+    if (fromMeta != null) {
+      BlockStateCache.setBlockedByOpponentForConversation(conversationId, opponentUserId, fromMeta);
+      return fromMeta;
+    }
+
+    Boolean fromLastMessage = parseBlockedByOpponentFromLastMessage(lastMessage, opponentUserId,
+        currentUserId, source + "#lastMessage");
+    if (fromLastMessage != null) {
+      BlockStateCache.setBlockedByOpponentForConversation(conversationId, opponentUserId, fromLastMessage);
+      return fromLastMessage;
+    }
+
+    if (messagingDisabled && opponentUserId != null) {
+      Boolean cached = BlockStateCache.getBlockedByOpponent(opponentUserId);
+      if (cached == null && conversationId != null) {
+        cached = BlockStateCache.getBlockedByOpponentForConversation(conversationId);
+      }
+      if (cached != null) {
+        log(source + "#cache", "resolved blockedByOpponent=" + cached + " opponentUserId=" + opponentUserId
+            + " conversationId=" + conversationId);
+        return cached;
+      }
+      log(source + "#cache",
+          "messagingDisabled=true but API has no blockedMessage (metaData empty or lastMessage is chat). "
+              + "opponentUserId=" + opponentUserId + " conversationId=" + conversationId
+              + " — need MQTT or persisted cache; backend should include metaData.customMetaData.blockedMessage");
+    }
+
+    return null;
+  }
+
+  @Nullable
+  private static JSONObject extractBlockedMessage(JSONObject metaData) {
+    JSONObject customMetaData = metaData.optJSONObject("customMetaData");
+    if (customMetaData != null && customMetaData.has("blockedMessage")) {
+      return customMetaData.optJSONObject("blockedMessage");
+    }
+    if (metaData.has("blockedMessage")) {
+      return metaData.optJSONObject("blockedMessage");
+    }
+    return null;
+  }
+
+  private static boolean readBoolean(JSONObject jsonObject, String key) {
+    Object value = jsonObject.opt(key);
+    if (value instanceof Boolean) {
+      return (Boolean) value;
+    }
+    if (value instanceof Number) {
+      return ((Number) value).intValue() != 0;
+    }
+    return Boolean.parseBoolean(jsonObject.optString(key, "false"));
+  }
+}

--- a/isometrik-chat/src/main/java/io/isometrik/ui/conversations/list/ConversationsListContract.kt
+++ b/isometrik-chat/src/main/java/io/isometrik/ui/conversations/list/ConversationsListContract.kt
@@ -313,6 +313,21 @@ interface ConversationsListContract {
         fun onMessagingStatusChanged(conversationId: String, disabled: Boolean)
 
         /**
+         * On messaging status changed for a 1-1 conversation matched by opponent user id.
+         *
+         * @param opponentUserId the opponent user id
+         * @param disabled the disabled
+         */
+        fun onMessagingStatusChangedByOpponentId(opponentUserId: String, disabled: Boolean)
+
+        /**
+         * Opponent blocked the current user in a 1-1 conversation.
+         *
+         * @param opponentUserId the opponent user id
+         */
+        fun onOpponentBlockedMe(opponentUserId: String)
+
+        /**
          * On conversation cleared.
          *
          * @param conversationId the conversation id

--- a/isometrik-chat/src/main/java/io/isometrik/ui/conversations/list/ConversationsListFragment.kt
+++ b/isometrik-chat/src/main/java/io/isometrik/ui/conversations/list/ConversationsListFragment.kt
@@ -20,6 +20,7 @@ import io.isometrik.chat.R
 import io.isometrik.chat.databinding.IsmFragmentConversationsBinding
 import io.isometrik.chat.enums.ConversationType
 import io.isometrik.chat.utils.AlertProgress
+import io.isometrik.chat.utils.BlockStatusUtil
 import io.isometrik.chat.utils.RecyclerItemClickListener
 import io.isometrik.ui.IsometrikChatSdk.Companion.instance
 import io.isometrik.ui.conversations.newconversation.type.SelectConversationTypeBottomSheet
@@ -410,6 +411,42 @@ class ConversationsListFragment : Fragment(), ConversationsListContract.View {
         }
     }
 
+    override fun onMessagingStatusChangedByOpponentId(opponentUserId: String, disabled: Boolean) {
+        if (activity != null) {
+            requireActivity().runOnUiThread {
+                val position = conversations.indexOfFirst {
+                    it.isPrivateOneToOneConversation && opponentUserId == it.opponentId
+                }
+                if (position != -1) {
+                    val conversationsModel = conversations[position]
+                    conversationsModel.isMessagingDisabled = disabled
+                    if (!disabled) {
+                        conversationsModel.setBlockedByOpponent(false)
+                    }
+                    conversations[position] = conversationsModel
+                    conversationsAdapter!!.notifyItemChanged(position)
+                }
+            }
+        }
+    }
+
+    override fun onOpponentBlockedMe(opponentUserId: String) {
+        if (activity != null) {
+            requireActivity().runOnUiThread {
+                val position = conversations.indexOfFirst {
+                    it.isPrivateOneToOneConversation && opponentUserId == it.opponentId
+                }
+                if (position != -1) {
+                    val conversationsModel = conversations[position]
+                    conversationsModel.isMessagingDisabled = true
+                    conversationsModel.setBlockedByOpponent(true)
+                    conversations[position] = conversationsModel
+                    conversationsAdapter!!.notifyItemChanged(position)
+                }
+            }
+        }
+    }
+
     override fun onConversationCleared(
         conversationId: String, lastMessageText: String,
         lastMessageTime: String
@@ -660,6 +697,15 @@ class ConversationsListFragment : Fragment(), ConversationsListContract.View {
                 intent.putExtra("messagingDisabled", true)
                 intent.putExtra("lastMessageText", conversationsModel.lastMessageText)
             }
+            intent.putExtra("opponentUserBlockedMe", conversationsModel.isBlockedByOpponent)
+            BlockStatusUtil.log(
+                "OpenMessagesScreen",
+                "conversationId=" + conversationsModel.conversationId
+                    + " messagingDisabled=" + conversationsModel.isMessagingDisabled
+                    + " opponentUserBlockedMe=" + conversationsModel.isBlockedByOpponent
+                    + " opponentId=" + conversationsModel.opponentId
+                    + " metaData=" + conversationsModel.metaData
+            )
         } else {
             intent.putExtra("conversationTitle", conversationsModel.conversationTitle)
             intent.putExtra("participantsCount", conversationsModel.conversationMembersCount)

--- a/isometrik-chat/src/main/java/io/isometrik/ui/conversations/list/ConversationsListPresenter.java
+++ b/isometrik-chat/src/main/java/io/isometrik/ui/conversations/list/ConversationsListPresenter.java
@@ -57,6 +57,8 @@ import io.isometrik.chat.R;
 import io.isometrik.ui.messages.chat.common.ChatConfig;
 import io.isometrik.ui.messages.reaction.util.ReactionPlaceHolderIconHelper;
 import io.isometrik.chat.utils.Constants;
+import io.isometrik.chat.utils.BlockStateCache;
+import io.isometrik.chat.utils.BlockStatusUtil;
 import io.isometrik.chat.utils.TimeUtil;
 import io.isometrik.chat.utils.UserSession;
 import java.util.ArrayList;
@@ -462,13 +464,36 @@ public class ConversationsListPresenter implements ConversationsListContract.Pre
   private final UserEventCallback userEventCallback = new UserEventCallback() {
     @Override
     public void userBlocked(@NotNull Isometrik isometrik, @NotNull BlockUserEvent blockUserEvent) {
-      //TODO Nothing
+      if (conversationsListView == null) {
+        return;
+      }
+      String currentUserId = IsometrikChatSdk.getInstance().getUserSession().getUserId();
+      if (blockUserEvent.getInitiatorId().equals(currentUserId)) {
+        BlockStateCache.setBlockedByOpponent(blockUserEvent.getOpponentId(), false);
+        conversationsListView.onMessagingStatusChangedByOpponentId(blockUserEvent.getOpponentId(), true);
+      } else if (blockUserEvent.getOpponentId().equals(currentUserId)) {
+        BlockStateCache.setBlockedByOpponent(blockUserEvent.getInitiatorId(), true);
+        conversationsListView.onOpponentBlockedMe(blockUserEvent.getInitiatorId());
+      }
     }
 
     @Override
     public void userUnblocked(@NotNull Isometrik isometrik,
         @NotNull UnblockUserEvent unblockUserEvent) {
-      //TODO Nothing
+      if (conversationsListView == null) {
+        return;
+      }
+      String currentUserId = IsometrikChatSdk.getInstance().getUserSession().getUserId();
+      String opponentUserId = null;
+      if (unblockUserEvent.getInitiatorId().equals(currentUserId)) {
+        opponentUserId = unblockUserEvent.getOpponentId();
+      } else if (unblockUserEvent.getOpponentId().equals(currentUserId)) {
+        opponentUserId = unblockUserEvent.getInitiatorId();
+      }
+      if (opponentUserId != null) {
+        BlockStateCache.setBlockedByOpponent(opponentUserId, false);
+        conversationsListView.onMessagingStatusChangedByOpponentId(opponentUserId, false);
+      }
     }
 
     @Override
@@ -942,32 +967,42 @@ public class ConversationsListPresenter implements ConversationsListContract.Pre
     public void blockedUserInConversation(@NotNull Isometrik isometrik,
         @NotNull BlockUserInConversationEvent blockUserInConversationEvent) {
       if (conversationsListView != null) {
-        String lastMessageText;
         String initiatorName = blockUserInConversationEvent.getInitiatorName();
         String opponentName = blockUserInConversationEvent.getOpponentName();
         String currentUserName = IsometrikChatSdk.getInstance().getUserSession().getUserName();
 
+        conversationsListView.onMessagingStatusChanged(
+            blockUserInConversationEvent.getConversationId(),
+            blockUserInConversationEvent.isMessagingDisabled());
+
         if (opponentName.equals(currentUserName)) {
+          BlockStateCache.setBlockedByOpponentForConversation(
+              blockUserInConversationEvent.getConversationId(),
+              blockUserInConversationEvent.getInitiatorId(), true);
+          conversationsListView.onOpponentBlockedMe(blockUserInConversationEvent.getInitiatorId());
+          return;
+        }
+
+        BlockStateCache.setBlockedByOpponentForConversation(
+            blockUserInConversationEvent.getConversationId(),
+            blockUserInConversationEvent.getOpponentId(), false);
+
+        String lastMessageText;
+        if (initiatorName.equals(currentUserName)) {
           lastMessageText = IsometrikChatSdk.getInstance().getContext().getString(
-                  R.string.ism_unblocked_user_text, initiatorName,"You");
-        } else if (initiatorName.equals(currentUserName)) {
-          lastMessageText = IsometrikChatSdk.getInstance().getContext().getString(
-                  R.string.ism_unblocked_user_text, "You",opponentName);
+              R.string.ism_blocked_user_text, "You", opponentName);
         } else {
           lastMessageText = IsometrikChatSdk.getInstance()
-                  .getContext()
-                  .getString(R.string.ism_unblocked_user,initiatorName, opponentName);
+              .getContext()
+              .getString(R.string.ism_blocked_user, initiatorName, opponentName);
         }
 
         conversationsListView.updateLastMessageInConversation(
-                blockUserInConversationEvent.getConversationId(), lastMessageText,
-                blockUserInConversationEvent.getInitiatorProfileImageUrl(),
-                TimeUtil.formatTimestampToOnlyDate(blockUserInConversationEvent.getSentAt()), null,
-                false, !blockUserInConversationEvent.getInitiatorId().equals(userId),
-                blockUserInConversationEvent.getInitiatorName(), true);
-        conversationsListView.onMessagingStatusChanged(
-                blockUserInConversationEvent.getConversationId(),
-                blockUserInConversationEvent.isMessagingDisabled());
+            blockUserInConversationEvent.getConversationId(), lastMessageText,
+            blockUserInConversationEvent.getInitiatorProfileImageUrl(),
+            TimeUtil.formatTimestampToOnlyDate(blockUserInConversationEvent.getSentAt()), null,
+            false, !blockUserInConversationEvent.getInitiatorId().equals(userId),
+            blockUserInConversationEvent.getInitiatorName(), true);
       }
     }
 
@@ -975,31 +1010,39 @@ public class ConversationsListPresenter implements ConversationsListContract.Pre
     public void unblockedUserInConversation(@NotNull Isometrik isometrik,
         @NotNull UnblockUserInConversationEvent unblockUserInConversationEvent) {
       if (conversationsListView != null) {
-        String lastMessageText;
         String initiatorName = unblockUserInConversationEvent.getInitiatorName();
         String opponentName = unblockUserInConversationEvent.getOpponentName();
         String currentUserName = IsometrikChatSdk.getInstance().getUserSession().getUserName();
 
+        conversationsListView.onMessagingStatusChanged(
+            unblockUserInConversationEvent.getConversationId(),
+            unblockUserInConversationEvent.isMessagingDisabled());
+
+        String unblockOpponentId = opponentName.equals(currentUserName)
+            ? unblockUserInConversationEvent.getInitiatorId()
+            : unblockUserInConversationEvent.getOpponentId();
+        BlockStateCache.clearConversation(unblockUserInConversationEvent.getConversationId(),
+            unblockOpponentId);
+
         if (opponentName.equals(currentUserName)) {
+          return;
+        }
+
+        String lastMessageText;
+        if (initiatorName.equals(currentUserName)) {
           lastMessageText = IsometrikChatSdk.getInstance().getContext().getString(
-                  R.string.ism_unblocked_user_text, initiatorName,"You");
-        } else if (initiatorName.equals(currentUserName)) {
-          lastMessageText = IsometrikChatSdk.getInstance().getContext().getString(
-                  R.string.ism_unblocked_user_text, "You",opponentName);
+              R.string.ism_unblocked_user_text, "You", opponentName);
         } else {
           lastMessageText = IsometrikChatSdk.getInstance()
-                  .getContext()
-                  .getString(R.string.ism_unblocked_user,initiatorName, opponentName);
+              .getContext()
+              .getString(R.string.ism_unblocked_user, initiatorName, opponentName);
         }
         conversationsListView.updateLastMessageInConversation(
-                unblockUserInConversationEvent.getConversationId(), lastMessageText,
-                unblockUserInConversationEvent.getInitiatorProfileImageUrl(),
-                TimeUtil.formatTimestampToOnlyDate(unblockUserInConversationEvent.getSentAt()), null,
-                false, !unblockUserInConversationEvent.getInitiatorId().equals(userId),
-                unblockUserInConversationEvent.getInitiatorName(), true);
-        conversationsListView.onMessagingStatusChanged(
-                unblockUserInConversationEvent.getConversationId(),
-                unblockUserInConversationEvent.isMessagingDisabled());
+            unblockUserInConversationEvent.getConversationId(), lastMessageText,
+            unblockUserInConversationEvent.getInitiatorProfileImageUrl(),
+            TimeUtil.formatTimestampToOnlyDate(unblockUserInConversationEvent.getSentAt()), null,
+            false, !unblockUserInConversationEvent.getInitiatorId().equals(userId),
+            unblockUserInConversationEvent.getInitiatorName(), true);
       }
     }
   };

--- a/isometrik-chat/src/main/java/io/isometrik/ui/conversations/list/ConversationsModel.java
+++ b/isometrik-chat/src/main/java/io/isometrik/ui/conversations/list/ConversationsModel.java
@@ -8,8 +8,10 @@ import io.isometrik.chat.enums.ConversationType;
 import io.isometrik.chat.events.conversation.CreateConversationEvent;
 import io.isometrik.chat.response.conversation.utils.Conversation;
 import io.isometrik.chat.response.conversation.utils.ConversationMember;
-import io.isometrik.ui.IsometrikChatSdk;
+import io.isometrik.chat.utils.BlockStatusUtil;
+import io.isometrik.chat.utils.BlockStateCache;
 import io.isometrik.chat.R;
+import io.isometrik.ui.IsometrikChatSdk;
 import io.isometrik.ui.messages.reaction.util.ReactionPlaceHolderIconHelper;
 import io.isometrik.chat.utils.TimeUtil;
 
@@ -41,6 +43,7 @@ public class ConversationsModel {
     private final boolean canJoin;
     private boolean messagingDisabled;
     private JSONObject metaData;
+    private boolean blockedByOpponent;
     private boolean lastMessageReadByAll, lastMessageDeliveredToAll;
     private String lastMessageCustomType;
 
@@ -161,6 +164,20 @@ public class ConversationsModel {
         }
         metaData = conversation.getMetaData();
         JSONObject lastMessageDetails = conversation.getLastMessageDetails();
+        Boolean resolvedBlockState = BlockStatusUtil.resolveBlockedByOpponent(metaData,
+            lastMessageDetails, conversationId, opponentId,
+            IsometrikChatSdk.getInstance().getUserSession().getUserId(), messagingDisabled,
+            "ConversationsModel");
+        if (resolvedBlockState != null) {
+            blockedByOpponent = resolvedBlockState;
+        }
+        BlockStatusUtil.log("ConversationsModel",
+            "conversationId=" + conversationId
+                + " messagingDisabled=" + messagingDisabled
+                + " blockedByOpponent=" + blockedByOpponent
+                + " opponentId=" + opponentId
+                + " lastMessageAction=" + (lastMessageDetails != null
+                    ? lastMessageDetails.optString("action", "none") : "null"));
         try {
             if (lastMessageDetails.has("customType")) {
                 lastMessageCustomType = lastMessageDetails.getString("customType");
@@ -282,15 +299,20 @@ public class ConversationsModel {
                         lastMessageSendersProfileImageUrl = lastMessage.getString("initiatorProfileImageUrl");
 
                         if (opponentName.equals(currentUserName)) {
+                            blockedByOpponent = true;
                             lastMessageText = IsometrikChatSdk.getInstance().getContext().getString(
                                     R.string.ism_blocked_user_text, initiatorName, "You");
                         } else if (initiatorName.equals(currentUserName)) {
+                            blockedByOpponent = false;
                             lastMessageText = IsometrikChatSdk.getInstance().getContext().getString(
                                     R.string.ism_blocked_user_text, "You", opponentName);
                         } else {
                             lastMessageText = IsometrikChatSdk.getInstance().getContext().getString(
                                     R.string.ism_blocked_user, initiatorName, opponentName);
                         }
+                        BlockStatusUtil.log("ConversationsModel",
+                            "userBlockConversation lastMessage blockedByOpponent=" + blockedByOpponent
+                                + " initiatorName=" + initiatorName + " opponentName=" + opponentName);
                         break;
                     }
 
@@ -1093,6 +1115,56 @@ public class ConversationsModel {
      */
     public void setMessagingDisabled(boolean messagingDisabled) {
         this.messagingDisabled = messagingDisabled;
+    }
+
+    /**
+     * Returns true when the opponent has blocked the current user in this conversation.
+     */
+    public boolean isBlockedByOpponent() {
+        if (blockedByOpponent) {
+            return true;
+        }
+        Boolean cached = BlockStateCache.getBlockedByOpponent(opponentId);
+        if (cached == null && conversationId != null) {
+            cached = BlockStateCache.getBlockedByOpponentForConversation(conversationId);
+        }
+        if (cached != null) {
+            return cached;
+        }
+        Boolean parsed = BlockStatusUtil.parseBlockedByOpponent(metaData, opponentId,
+            IsometrikChatSdk.getInstance().getUserSession().getUserId(),
+            "ConversationsModel#isBlockedByOpponent");
+        return parsed != null && parsed;
+    }
+
+    /**
+     * Returns true when the current user blocked the opponent (show block indicator in list).
+     */
+    public boolean hasBlockedOpponent() {
+        if (!messagingDisabled) {
+            return false;
+        }
+        if (blockedByOpponent) {
+            return false;
+        }
+        Boolean direction = BlockStateCache.getBlockedByOpponent(opponentId);
+        if (direction == null && conversationId != null) {
+            direction = BlockStateCache.getBlockedByOpponentForConversation(conversationId);
+        }
+        if (direction != null) {
+            return !direction;
+        }
+        Boolean parsed = BlockStatusUtil.parseBlockedByOpponent(metaData, opponentId,
+            IsometrikChatSdk.getInstance().getUserSession().getUserId(),
+            "ConversationsModel#hasBlockedOpponent");
+        if (parsed != null) {
+            return !parsed;
+        }
+        return false;
+    }
+
+    public void setBlockedByOpponent(boolean blockedByOpponent) {
+        this.blockedByOpponent = blockedByOpponent;
     }
 
     /**

--- a/isometrik-chat/src/main/java/io/isometrik/ui/conversations/list/DefaultChatListItemBinder.kt
+++ b/isometrik-chat/src/main/java/io/isometrik/ui/conversations/list/DefaultChatListItemBinder.kt
@@ -32,7 +32,7 @@ class DefaultChatListItemBinder :
     ) {
 
         try {
-            if (conversationsModel.isMessagingDisabled) {
+            if (conversationsModel.hasBlockedOpponent()) {
                 val spannableString = SpannableString(conversationsModel.conversationTitle)
                 spannableString.setSpan(StyleSpan(Typeface.ITALIC), 0, spannableString.length, 0)
                 ismConversationItemBinding.tvConversationTitle.text = spannableString
@@ -43,7 +43,7 @@ class DefaultChatListItemBinder :
             val lastMessageText = conversationsModel.lastMessageText
             if (lastMessageText != null && !containsKeyword(lastMessageText, hideMessagekeywords)) {
                 ismConversationItemBinding.tvLastMessage.text = lastMessageText
-            } else if (lastMessageText == null) {
+            } else {
                 ismConversationItemBinding.tvLastMessage.text = ""
             }
             if (conversationsModel.isCanJoin) {
@@ -82,29 +82,27 @@ class DefaultChatListItemBinder :
                 )
             }
             if (conversationsModel.isPrivateOneToOneConversation) {
-                if (conversationsModel.isMessagingDisabled) {
+                if (conversationsModel.hasBlockedOpponent()) {
                     ismConversationItemBinding.ivOnlineStatus.setImageDrawable(
                             ContextCompat.getDrawable(
                                     mContext,
                                     R.drawable.ism_ic_messaging_disabled
                             )
                     )
+                } else if (conversationsModel.isOnline) {
+                    ismConversationItemBinding.ivOnlineStatus.setImageDrawable(
+                            ContextCompat.getDrawable(
+                                    mContext,
+                                    R.drawable.ism_user_online_status_circle
+                            )
+                    )
                 } else {
-                    if (conversationsModel.isOnline) {
-                        ismConversationItemBinding.ivOnlineStatus.setImageDrawable(
-                                ContextCompat.getDrawable(
-                                        mContext,
-                                        R.drawable.ism_user_online_status_circle
-                                )
-                        )
-                    } else {
-                        ismConversationItemBinding.ivOnlineStatus.setImageDrawable(
-                                ContextCompat.getDrawable(
-                                        mContext,
-                                        R.drawable.ism_user_offline_status_circle
-                                )
-                        )
-                    }
+                    ismConversationItemBinding.ivOnlineStatus.setImageDrawable(
+                            ContextCompat.getDrawable(
+                                    mContext,
+                                    R.drawable.ism_user_offline_status_circle
+                            )
+                    )
                 }
                 ismConversationItemBinding.ivOnlineStatus.visibility = View.VISIBLE
             } else {

--- a/isometrik-chat/src/main/java/io/isometrik/ui/messages/chat/ConversationMessagesActivity.kt
+++ b/isometrik-chat/src/main/java/io/isometrik/ui/messages/chat/ConversationMessagesActivity.kt
@@ -57,6 +57,7 @@ import io.isometrik.chat.enums.MessageTypeUi
 import io.isometrik.chat.enums.PresignedUrlMediaTypes
 import io.isometrik.chat.response.conversation.utils.ConversationDetailsUtil
 import io.isometrik.chat.utils.AlertProgress
+import io.isometrik.chat.utils.BlockStatusUtil
 import io.isometrik.chat.utils.Constants
 import io.isometrik.chat.utils.FileUriUtils.getRealPath
 import io.isometrik.chat.utils.GalleryIntentsUtil
@@ -236,7 +237,14 @@ class ConversationMessagesActivity : AppCompatActivity(), ConversationMessagesCo
         alertProgress = AlertProgress()
         conversationMessagesPresenter = ConversationMessagesPresenter(this, this)
 
-        messagingDisabled = intent.extras!!.containsKey("messagingDisabled")
+        messagingDisabled = intent.extras!!.getBoolean("messagingDisabled", false)
+        opponentUserBlockedMe = intent.extras!!.getBoolean("opponentUserBlockedMe", false)
+        BlockStatusUtil.log(
+            "ConversationMessagesActivity",
+            "onCreate conversationId=" + intent.extras!!.getString("conversationId")
+                + " messagingDisabled=" + messagingDisabled
+                + " opponentUserBlockedMe=" + opponentUserBlockedMe
+        )
         if (messagingDisabled) {
             lastMessageText = intent.extras!!.getString("lastMessageText")
         }
@@ -260,8 +268,11 @@ class ConversationMessagesActivity : AppCompatActivity(), ConversationMessagesCo
                 ismActivityMessagesBinding.rlBottomLayout.visibility =
                     if (visiable) View.VISIBLE else View.GONE
 
-                ismActivityMessagesBinding.rlRecordAudio.visibility =
-                if (!ChatConfig.hideRecordAudioOption && visiable) View.VISIBLE else View.GONE
+                if (!visiable) {
+                    ismActivityMessagesBinding.rlRecordAudio.visibility = View.GONE
+                } else {
+                    updateComposerActionVisibility()
+                }
             }
         }
 
@@ -382,9 +393,9 @@ class ConversationMessagesActivity : AppCompatActivity(), ConversationMessagesCo
             joiningAsObserver
         )
 
+        conversationMessagesPresenter.setOpponentUserBlockedMe(opponentUserBlockedMe)
         if (messagingDisabled) {
-            onMessagingStatusChanged(true)
-            opponentUserBlockedMe = !lastMessageText!!.startsWith("You")
+            applyMessagingRestrictionUi()
         }
         updateConversationDetailsInHeader(true, isPrivateOneToOne, null, false, 0, null, 0,conversationUserImageUrl.orEmpty())
 
@@ -473,6 +484,7 @@ class ConversationMessagesActivity : AppCompatActivity(), ConversationMessagesCo
                     if (result.data!!.getBooleanExtra("conversationLeftOrDeleted", false)) {
                         onBackPressed()
                     } else if (result.data!!.getBooleanExtra("messagingBlocked", false)) {
+                        opponentUserBlockedMe = false
                         onMessagingStatusChanged(true)
                     } else if (result.data!!.getBooleanExtra("searchMessageRequested", false)) {
                         if (ismActivityMessagesBinding!!.rlSearch.visibility == View.GONE) {
@@ -1189,74 +1201,59 @@ class ConversationMessagesActivity : AppCompatActivity(), ConversationMessagesCo
         }
 
         ismActivityMessagesBinding!!.ivMore.setOnClickListener { v: View? ->
-            if (opponentUserBlockedMe) { // condition used for opponentUser Blocked
-                Toast.makeText(
-                    this,
-                    R.string.ism_blocked_action,
-                    Toast.LENGTH_SHORT
-                ).show()
-            } else {
-                if ((ismActivityMessagesBinding!!.vSelectMultipleMessagesHeader.root.isGone) && clickActionsNotBlocked()
-                ) {
-                    val popup = PopupMenu(this, v)
-                    val inflater = popup.menuInflater
-                    if (messagingDisabled) {
-                        inflater.inflate(R.menu.ism_unblock_menu, popup.menu)
-                    } else {
-                        inflater.inflate(R.menu.ism_block_menu, popup.menu)
+            if ((ismActivityMessagesBinding!!.vSelectMultipleMessagesHeader.root.isGone) && clickActionsNotBlocked()
+            ) {
+                val popup = PopupMenu(this, v)
+                val inflater = popup.menuInflater
+                if (messagingDisabled && !opponentUserBlockedMe) {
+                    inflater.inflate(R.menu.ism_unblock_menu, popup.menu)
+                } else {
+                    inflater.inflate(R.menu.ism_block_menu, popup.menu)
+                    if (shouldHideBlockMenuOption()) {
+                        popup.menu.findItem(R.id.blockOrUnBlockUser)?.isVisible = false
                     }
-                    popup.setOnMenuItemClickListener { item: MenuItem ->
-                        if (item.itemId == R.id.blockOrUnBlockUser) {
-                            if (messagingDisabled) {
-                                showProgressDialog(
-                                    getString(
-                                        R.string.ism_unblocking_user,
-                                        conversationUserFullName
-                                    )
+                }
+                popup.setOnMenuItemClickListener { item: MenuItem ->
+                    if (item.itemId == R.id.blockOrUnBlockUser) {
+                        if (messagingDisabled && !opponentUserBlockedMe) {
+                            showProgressDialog(
+                                getString(
+                                    R.string.ism_unblocking_user,
+                                    conversationUserFullName
                                 )
-                                conversationMessagesPresenter.unBlockUser(
-                                    isometrikUserId,
-                                    false,
-                                    userPersonalUserId
-                                )
-                            } else {
-                                showProgressDialog(
-                                    getString(
-                                        R.string.ism_blocking_user,
-                                        conversationUserFullName
-                                    )
-                                )
-                                conversationMessagesPresenter.blockUser(
-                                    isometrikUserId,
-                                    true,
-                                    userPersonalUserId
+                            )
+                            conversationMessagesPresenter.unBlockUser(
+                                isometrikUserId,
+                                false,
+                                userPersonalUserId
+                            )
+                        } else {
+                            showBlockUserConfirmationDialog()
+                        }
+                        return@setOnMenuItemClickListener true
+                    }
+                    if (item.itemId == R.id.clearChat) {
+                        // implement clear chat feature
+                        AlertDialog.Builder(this)
+                            .setTitle(getString(R.string.ism_clear_conversation))
+                            .setMessage(getString(R.string.ism_clear_conversation_alert))
+                            .setCancelable(true)
+                            .setPositiveButton(getString(R.string.ism_continue)) { dialog: DialogInterface, id: Int ->
+                                dialog.cancel()
+                                showProgressDialog(getString(R.string.ism_clearing_conversation))
+                                conversationMessagesPresenter.clearConversation(
+                                    conversationId
                                 )
                             }
-                            return@setOnMenuItemClickListener true
-                        }
-                        if (item.itemId == R.id.clearChat) {
-                            // implement clear chat feature
-                            AlertDialog.Builder(this)
-                                .setTitle(getString(R.string.ism_clear_conversation))
-                                .setMessage(getString(R.string.ism_clear_conversation_alert))
-                                .setCancelable(true)
-                                .setPositiveButton(getString(R.string.ism_continue)) { dialog: DialogInterface, id: Int ->
-                                    dialog.cancel()
-                                    showProgressDialog(getString(R.string.ism_clearing_conversation))
-                                    conversationMessagesPresenter.clearConversation(
-                                        conversationId
-                                    )
-                                }
-                                .setNegativeButton(
-                                    getString(R.string.ism_cancel)
-                                ) { dialog: DialogInterface, id: Int -> dialog.cancel() }
-                                .create()
-                                .show()
-                        }
-                        false
+                            .setNegativeButton(
+                                getString(R.string.ism_cancel)
+                            ) { dialog: DialogInterface, id: Int -> dialog.cancel() }
+                            .create()
+                            .show()
                     }
-                    popup.show()
+                    false
                 }
+                popup.show()
             }
         }
 
@@ -1289,7 +1286,112 @@ class ConversationMessagesActivity : AppCompatActivity(), ConversationMessagesCo
     }
 
     override fun blockedStatus(blockByOpponentUser: Boolean) {
-        opponentUserBlockedMe = blockByOpponentUser
+        runOnUiThread {
+            BlockStatusUtil.log(
+                "ConversationMessagesActivity",
+                "blockedStatus blockByOpponentUser=" + blockByOpponentUser
+                    + " (was opponentUserBlockedMe=" + opponentUserBlockedMe + ")"
+            )
+            opponentUserBlockedMe = blockByOpponentUser
+            conversationMessagesPresenter.setOpponentUserBlockedMe(blockByOpponentUser)
+            applyMessagingRestrictionUi()
+        }
+    }
+
+    private fun shouldShowBlockerUi(): Boolean {
+        val show = messagingDisabled && !opponentUserBlockedMe
+        BlockStatusUtil.log(
+            "ConversationMessagesActivity",
+            "shouldShowBlockerUi=" + show
+                + " messagingDisabled=" + messagingDisabled
+                + " opponentUserBlockedMe=" + opponentUserBlockedMe
+        )
+        return show
+    }
+
+    private fun shouldHideBlockMenuOption(): Boolean {
+        return ChatConfig.hideBlockOptionWhenBlockedByOpponent
+            && messagingDisabled && opponentUserBlockedMe
+    }
+
+    private fun updateComposerActionVisibility() {
+        val binding = ismActivityMessagesBinding ?: return
+        if (shouldShowBlockerUi()) {
+            binding.rlRecordAudio.visibility = View.GONE
+            return
+        }
+        val hasText = binding.etSendMessage.text?.isNotEmpty() == true
+        binding.rlRecordAudio.visibility =
+            if (ChatConfig.hideRecordAudioOption || hasText) View.GONE else View.VISIBLE
+        binding.ivCaptureImage.visibility =
+            if (ChatConfig.hideCaptureCameraOption || hasText) View.GONE else View.VISIBLE
+    }
+
+    private fun applyMessagingRestrictionUi() {
+        val showBlockerUi = shouldShowBlockerUi()
+        ismActivityMessagesBinding!!.rlBottomLayout.visibility =
+            if (showBlockerUi) View.INVISIBLE else View.VISIBLE
+        updateComposerActionVisibility()
+        ismActivityMessagesBinding!!.rlDeleteConversation.visibility =
+            if (showBlockerUi) View.VISIBLE else View.GONE
+        if (!ChatConfig.hideAudioCallOption) {
+            ismActivityMessagesBinding!!.ivAudioCall.visibility =
+                if (showBlockerUi) View.GONE else View.VISIBLE
+        }
+        if (!ChatConfig.hideVideoCallOption) {
+            ismActivityMessagesBinding!!.ivVideoCall.visibility =
+                if (showBlockerUi) View.GONE else View.VISIBLE
+        }
+        if (showBlockerUi) {
+            if (!conversationMessagesAdapter!!.isMessagingDisabled) {
+                conversationMessagesAdapter!!.isMessagingDisabled = true
+                conversationMessagesAdapter!!.notifyDataSetChanged()
+            }
+            ismActivityMessagesBinding!!.ivOnlineStatus.setImageDrawable(
+                ContextCompat.getDrawable(this, R.drawable.ism_ic_blocked)
+            )
+            ismActivityMessagesBinding!!.tvParticipantsCountOrOnlineStatus.text =
+                getString(R.string.ism_unavailable)
+            val userName = conversationUserFullName.orEmpty()
+            val spannableString = SpannableString(userName)
+            spannableString.setSpan(StyleSpan(Typeface.ITALIC), 0, spannableString.length, 0)
+            ismActivityMessagesBinding!!.tvConversationOrUserName.text = spannableString
+        } else if (messagingDisabled && opponentUserBlockedMe) {
+            if (conversationMessagesAdapter!!.isMessagingDisabled) {
+                conversationMessagesAdapter!!.isMessagingDisabled = false
+                conversationMessagesAdapter!!.notifyDataSetChanged()
+            }
+        } else if (!messagingDisabled) {
+            if (conversationMessagesAdapter!!.isMessagingDisabled) {
+                conversationMessagesAdapter!!.isMessagingDisabled = false
+                conversationMessagesAdapter!!.notifyDataSetChanged()
+            }
+            ismActivityMessagesBinding!!.tvConversationOrUserName.text = conversationUserFullName
+        }
+    }
+
+    private fun showBlockUserConfirmationDialog() {
+        val dialogView = layoutInflater.inflate(R.layout.ism_dialog_block_user, null)
+        dialogView.findViewById<TextView>(R.id.tvBlockDialogTitle).text =
+            getString(R.string.ism_block_user_dialog_title, conversationUserFullName)
+        val blockDialog = AlertDialog.Builder(this)
+            .setView(dialogView)
+            .create()
+        dialogView.findViewById<TextView>(R.id.tvCancel).setOnClickListener {
+            blockDialog.dismiss()
+        }
+        dialogView.findViewById<TextView>(R.id.tvBlock).setOnClickListener {
+            blockDialog.dismiss()
+            showProgressDialog(
+                getString(R.string.ism_blocking_user, conversationUserFullName)
+            )
+            conversationMessagesPresenter.blockUser(
+                isometrikUserId,
+                true,
+                userPersonalUserId
+            )
+        }
+        blockDialog.show()
     }
 
     private fun showProgressDialog(message: String) {
@@ -1319,18 +1421,7 @@ class ConversationMessagesActivity : AppCompatActivity(), ConversationMessagesCo
         }
 
         override fun onTextChanged(s: CharSequence, start: Int, before: Int, count: Int) {
-            if (s.length > 0) {
-                ismActivityMessagesBinding!!.rlRecordAudio.visibility = View.GONE
-                ismActivityMessagesBinding!!.ivCaptureImage.visibility = View.GONE
-//                ismActivityMessagesBinding.ivAddAttachment2.visibility = View.GONE
-            } else {
-                ismActivityMessagesBinding.ivCaptureImage.visibility =
-                    if (ChatConfig.hideCaptureCameraOption) View.GONE else View.VISIBLE
-                ismActivityMessagesBinding!!.rlRecordAudio.visibility =
-                if (ChatConfig.hideRecordAudioOption) View.GONE else View.VISIBLE
-//                ismActivityMessagesBinding.ivAddAttachment2.visibility = View.VISIBLE
-
-            }
+            updateComposerActionVisibility()
             if (!joiningAsObserver) conversationMessagesPresenter!!.sendTypingMessage()
         }
 
@@ -3077,7 +3168,7 @@ class ConversationMessagesActivity : AppCompatActivity(), ConversationMessagesCo
                     }
                 }
             }
-            if (messagingDisabled) {
+            if (shouldShowBlockerUi()) {
                 ismActivityMessagesBinding!!.ivOnlineStatus.setImageDrawable(
                     ContextCompat.getDrawable(
                         this, R.drawable.ism_ic_blocked
@@ -3201,36 +3292,7 @@ class ConversationMessagesActivity : AppCompatActivity(), ConversationMessagesCo
     override fun onMessagingStatusChanged(disabled: Boolean) {
         runOnUiThread {
             messagingDisabled = disabled
-            ismActivityMessagesBinding!!.rlBottomLayout.visibility =
-                if (disabled) View.INVISIBLE else View.VISIBLE
-            ismActivityMessagesBinding!!.rlRecordAudio.visibility =
-                if (disabled) View.GONE else View.VISIBLE
-            ismActivityMessagesBinding!!.rlDeleteConversation.visibility =
-                if (disabled) View.VISIBLE else View.GONE
-            if (disabled) {
-                if (!conversationMessagesAdapter!!.isMessagingDisabled) {
-                    conversationMessagesAdapter!!.isMessagingDisabled = true
-                    conversationMessagesAdapter!!.notifyDataSetChanged()
-                }
-                ismActivityMessagesBinding!!.ivOnlineStatus.setImageDrawable(
-                    ContextCompat.getDrawable(
-                        this,
-                        R.drawable.ism_ic_blocked
-                    )
-                )
-                ismActivityMessagesBinding!!.tvParticipantsCountOrOnlineStatus.text =
-                    getString(R.string.ism_unavailable)
-                //                ismActivityMessagesBinding.ivRefreshOnlineStatus.setVisibility(View.GONE);
-            } else {
-                if (conversationMessagesAdapter!!.isMessagingDisabled) {
-                    conversationMessagesAdapter!!.isMessagingDisabled = false
-                    conversationMessagesAdapter!!.notifyDataSetChanged()
-                }
-                if (conversationMessagesPresenter!!.isPrivateOneToOne) {
-//                    ismActivityMessagesBinding.ivRefreshOnlineStatus.setVisibility(View.VISIBLE);
-                    conversationMessagesPresenter!!.requestConversationDetails()
-                }
-            }
+            applyMessagingRestrictionUi()
         }
     }
 
@@ -3401,6 +3463,7 @@ class ConversationMessagesActivity : AppCompatActivity(), ConversationMessagesCo
             userPersonalUserId!!
         )
         hideProgressDialog()
+        opponentUserBlockedMe = false
         onMessagingStatusChanged(true)
     }
 
@@ -3410,6 +3473,7 @@ class ConversationMessagesActivity : AppCompatActivity(), ConversationMessagesCo
             userPersonalUserId!!
         )
         hideProgressDialog()
+        opponentUserBlockedMe = false
         onMessagingStatusChanged(false)
     }
 

--- a/isometrik-chat/src/main/java/io/isometrik/ui/messages/chat/ConversationMessagesContract.kt
+++ b/isometrik-chat/src/main/java/io/isometrik/ui/messages/chat/ConversationMessagesContract.kt
@@ -377,6 +377,8 @@ interface ConversationMessagesContract {
          * @param conversationId the conversation id
          */
         fun clearConversation(conversationId: String?)
+
+        fun setOpponentUserBlockedMe(opponentUserBlockedMe: Boolean)
     }
 
     /**

--- a/isometrik-chat/src/main/java/io/isometrik/ui/messages/chat/ConversationMessagesPresenter.java
+++ b/isometrik-chat/src/main/java/io/isometrik/ui/messages/chat/ConversationMessagesPresenter.java
@@ -86,6 +86,8 @@ import io.isometrik.chat.response.message.utils.schemas.Attachment;
 import io.isometrik.chat.response.message.utils.schemas.EventForMessage;
 import io.isometrik.chat.response.message.utils.schemas.MentionedUser;
 import io.isometrik.chat.enums.MessageTypeUi;
+import io.isometrik.chat.utils.BlockStateCache;
+import io.isometrik.chat.utils.BlockStatusUtil;
 import io.isometrik.chat.utils.LogManger;
 import io.isometrik.chat.utils.upload.CustomUploadHandler;
 import io.isometrik.chat.utils.upload.UploadedMediaResponse;
@@ -177,7 +179,7 @@ public class ConversationMessagesPresenter implements ConversationMessagesContra
     private long lastSeenAt;
     private boolean isOnline;
     private String conversationImageUrl, conversationTitle;
-    private boolean scrollToMessageNeeded, activeInConversation, joiningAsObserver;
+    private boolean scrollToMessageNeeded, activeInConversation, joiningAsObserver, opponentUserBlockedMe;
     private String messageIdToScrollTo;
 
     @Override
@@ -201,7 +203,11 @@ public class ConversationMessagesPresenter implements ConversationMessagesContra
                 lastSeenAt = extras.getLong("lastSeenAt", 0);
             }
             userId = extras.getString("userId");
-
+            opponentUserBlockedMe = extras.getBoolean("opponentUserBlockedMe", false);
+            BlockStatusUtil.log("InitializeConversation",
+                "conversationId=" + conversationId
+                    + " opponentUserBlockedMe(fromIntent)=" + opponentUserBlockedMe
+                    + " opponentUserId=" + userId);
             checkIfMessagingEnabled();
         } else {
             conversationTitle = extras.getString("conversationTitle");
@@ -279,7 +285,6 @@ public class ConversationMessagesPresenter implements ConversationMessagesContra
 
         MessagesModel messageModel = null;
 
-
         if (uploadMediaRequired) {
             Map<String, Map<String, String>> mediaDetailsMap = new HashMap<>();
             for (int i = 0; i < mediaPaths.size(); i++) {
@@ -355,6 +360,9 @@ public class ConversationMessagesPresenter implements ConversationMessagesContra
                     messageModel.setMediaId(mediaId);
                     conversationMessagesView.addSentMessageInUILocally(messageModel, true);
                 }
+            }
+            if (opponentUserBlockedMe) {
+                return;
             }
             requestPresignedUrls(conversationId, messageType, parentMessageId, customMessageType.value, messageBody,
                     encrypted, showInConversation, sendPushNotification, updateUnreadCount, messageMetadata,
@@ -463,6 +471,10 @@ public class ConversationMessagesPresenter implements ConversationMessagesContra
             if (messageModel != null) {
 
                 conversationMessagesView.addSentMessageInUILocally(messageModel, false);
+            }
+
+            if (opponentUserBlockedMe) {
+                return;
             }
 
             SendMessageQuery.Builder sendMessageQuery = new SendMessageQuery.Builder().setUserToken(userToken)
@@ -840,6 +852,9 @@ public class ConversationMessagesPresenter implements ConversationMessagesContra
 
     @Override
     public void sendTypingMessage() {
+        if (opponentUserBlockedMe) {
+            return;
+        }
         if (typingEventsEnabled) {
             SendTypingMessageQuery.Builder sendTypingMessageQuery =
                     new SendTypingMessageQuery.Builder().setUserToken(userToken)
@@ -903,6 +918,9 @@ public class ConversationMessagesPresenter implements ConversationMessagesContra
                             }
 
                             if (message.getConversationStatusMessage() != null && !isAudioVideoCall) {
+                                if (shouldHideBlockStatusMessage(message)) {
+                                    continue;
+                                }
                                 String conversationActionMessage =
                                         ConversationActionMessageUtil.parseConversationActionMessage(message);
 
@@ -1162,17 +1180,25 @@ public class ConversationMessagesPresenter implements ConversationMessagesContra
         public void userBlocked(@NotNull Isometrik isometrik, @NotNull BlockUserEvent blockUserEvent) {
 
             if (isPrivateOneToOne) {
-                if (blockUserEvent.getInitiatorId()
-                        .equals(IsometrikChatSdk.getInstance().getUserSession().getUserId())) {
-
+                String currentUserId = IsometrikChatSdk.getInstance().getUserSession().getUserId();
+                BlockStatusUtil.log("MQTT userBlocked",
+                    "initiatorId=" + blockUserEvent.getInitiatorId()
+                        + " opponentId=" + blockUserEvent.getOpponentId()
+                        + " currentUserId=" + currentUserId
+                        + " chatOpponentUserId=" + userId);
+                if (blockUserEvent.getInitiatorId().equals(currentUserId)) {
                     if (blockUserEvent.getOpponentId().equals(userId)) {
-                        conversationMessagesView.onMessagingStatusChanged(true);
+                        opponentUserBlockedMe = false;
+                        BlockStateCache.setBlockedByOpponentForConversation(conversationId, userId, false);
                         conversationMessagesView.blockedStatus(false);
+                        conversationMessagesView.onMessagingStatusChanged(true);
                     }
-                } else if (blockUserEvent.getInitiatorId().equals(userId)) {
-                    conversationMessagesView.onMessagingStatusChanged(true);
+                } else if (blockUserEvent.getOpponentId().equals(currentUserId)
+                        && blockUserEvent.getInitiatorId().equals(userId)) {
+                    opponentUserBlockedMe = true;
+                    BlockStateCache.setBlockedByOpponentForConversation(conversationId, userId, true);
                     conversationMessagesView.blockedStatus(true);
-
+                    conversationMessagesView.onMessagingStatusChanged(true);
                 }
             }
         }
@@ -1185,9 +1211,11 @@ public class ConversationMessagesPresenter implements ConversationMessagesContra
                         .equals(IsometrikChatSdk.getInstance().getUserSession().getUserId())) {
 
                     if (unblockUserEvent.getOpponentId().equals(userId)) {
+                        conversationMessagesView.blockedStatus(false);
                         checkIfMessagingEnabled();
                     }
                 } else if (unblockUserEvent.getInitiatorId().equals(userId)) {
+                    conversationMessagesView.blockedStatus(false);
                     checkIfMessagingEnabled();
                 }
             }
@@ -1658,28 +1686,39 @@ public class ConversationMessagesPresenter implements ConversationMessagesContra
         @Override
         public void blockedUserInConversation(@NotNull Isometrik isometrik,
                                               @NotNull BlockUserInConversationEvent blockUserInConversationEvent) {
-            MessagesModel messagesModel =
-                    RealtimeMessageUtil.parseUserBlockEvent(blockUserInConversationEvent);
             String initiatorName = blockUserInConversationEvent.getInitiatorName();
             String opponentName = blockUserInConversationEvent.getOpponentName();
+            String currentUserName = IsometrikChatSdk.getInstance().getUserSession().getUserName();
+            boolean blockedByOpponent = opponentName.equals(currentUserName);
 
-            if (opponentName.equals(IsometrikChatSdk.getInstance().getUserSession().getUserName())) { // opponentUser blocked
+            if (blockedByOpponent) {
                 conversationMessagesView.blockedStatus(true);
-            } else if (initiatorName.equals(IsometrikChatSdk.getInstance().getUserSession().getUserName())) { // selfUser Blocked
+            } else if (initiatorName.equals(currentUserName)) {
                 conversationMessagesView.blockedStatus(false);
             }
+
             if (blockUserInConversationEvent.getConversationId().equals(conversationId)) {
-                conversationMessagesView.addMessageInUI(messagesModel);
-                conversationMessagesView.onMessagingStatusChanged(
-                        blockUserInConversationEvent.isMessagingDisabled());
+                if (blockedByOpponent) {
+                    conversationMessagesView.onMessagingStatusChanged(true);
+                } else {
+                    conversationMessagesView.onMessagingStatusChanged(
+                            blockUserInConversationEvent.isMessagingDisabled());
+                }
+                if (!blockedByOpponent) {
+                    MessagesModel messagesModel =
+                            RealtimeMessageUtil.parseUserBlockEvent(blockUserInConversationEvent);
+                    conversationMessagesView.addMessageInUI(messagesModel);
+                }
                 if (!blockUserInConversationEvent.getInitiatorId()
                         .equals(IsometrikChatSdk.getInstance().getUserSession().getUserId())) {
                     updateLastReadInConversation();
                 }
             } else {
                 if (!blockUserInConversationEvent.getInitiatorId()
-                        .equals(IsometrikChatSdk.getInstance().getUserSession().getUserId())) {
-
+                        .equals(IsometrikChatSdk.getInstance().getUserSession().getUserId())
+                        && !blockedByOpponent) {
+                    MessagesModel messagesModel =
+                            RealtimeMessageUtil.parseUserBlockEvent(blockUserInConversationEvent);
                     conversationMessagesView.showMessageNotification(
                             blockUserInConversationEvent.getConversationId(),
                             blockUserInConversationEvent.getInitiatorName(),
@@ -1694,29 +1733,31 @@ public class ConversationMessagesPresenter implements ConversationMessagesContra
         @Override
         public void unblockedUserInConversation(@NotNull Isometrik isometrik,
                                                 @NotNull UnblockUserInConversationEvent unblockUserInConversationEvent) {
-            MessagesModel messagesModel =
-                    RealtimeMessageUtil.parseUserUnblockEvent(unblockUserInConversationEvent);
             String initiatorName = unblockUserInConversationEvent.getInitiatorName();
             String opponentName = unblockUserInConversationEvent.getOpponentName();
+            String currentUserName = IsometrikChatSdk.getInstance().getUserSession().getUserName();
+            boolean unblockedByOpponent = opponentName.equals(currentUserName);
 
-            if (opponentName.equals(IsometrikChatSdk.getInstance().getUserSession().getUserName())) { // opponentUser unBlocked
-                conversationMessagesView.blockedStatus(false);
-            } else if (initiatorName.equals(IsometrikChatSdk.getInstance().getUserSession().getUserName())) { // selfUser unBlocked
-                conversationMessagesView.blockedStatus(false);
-            }
+            conversationMessagesView.blockedStatus(false);
 
             if (unblockUserInConversationEvent.getConversationId().equals(conversationId)) {
-                conversationMessagesView.addMessageInUI(messagesModel);
                 conversationMessagesView.onMessagingStatusChanged(
                         unblockUserInConversationEvent.isMessagingDisabled());
+                if (!unblockedByOpponent) {
+                    MessagesModel messagesModel =
+                            RealtimeMessageUtil.parseUserUnblockEvent(unblockUserInConversationEvent);
+                    conversationMessagesView.addMessageInUI(messagesModel);
+                }
                 if (!unblockUserInConversationEvent.getInitiatorId()
                         .equals(IsometrikChatSdk.getInstance().getUserSession().getUserId())) {
                     updateLastReadInConversation();
                 }
             } else {
                 if (!unblockUserInConversationEvent.getInitiatorId()
-                        .equals(IsometrikChatSdk.getInstance().getUserSession().getUserId())) {
-
+                        .equals(IsometrikChatSdk.getInstance().getUserSession().getUserId())
+                        && !unblockedByOpponent) {
+                    MessagesModel messagesModel =
+                            RealtimeMessageUtil.parseUserUnblockEvent(unblockUserInConversationEvent);
                     conversationMessagesView.showMessageNotification(
                             unblockUserInConversationEvent.getConversationId(),
                             unblockUserInConversationEvent.getInitiatorName(),
@@ -2129,28 +2170,25 @@ public class ConversationMessagesPresenter implements ConversationMessagesContra
                                     }
                                 }
                                 if (Boolean.TRUE.equals(conversationDetailsUtil.getMessagingDisabled())) {
-                                    conversationMessagesView.onMessagingStatusChanged(true);
-                                    boolean blockByOpponentUser = false;
-                                    try {
-                                        JSONObject metaData = conversationDetailsUtil.getMetaData();
-                                        if (metaData != null && metaData.has("customMetaData")) {
-                                            JSONObject customMetaData = metaData.optJSONObject("customMetaData");
-                                            if (customMetaData != null && customMetaData.has("blockedMessage")) {
-                                                JSONObject blockedMessage = customMetaData.optJSONObject("blockedMessage");
-                                                if (blockedMessage != null && blockedMessage.has("initiatorId")) {
-                                                    String initiatorId = blockedMessage.optString("initiatorId", null);
-                                                    String opponentUserId = conversationDetailsUtil.getOpponentDetails() != null
-                                                            ? conversationDetailsUtil.getOpponentDetails().getUserId() : null;
-                                                    blockByOpponentUser = initiatorId != null && !initiatorId.isEmpty()
-                                                            && opponentUserId != null && initiatorId.equals(opponentUserId);
-                                                }
-                                            }
-                                        }
-                                    } catch (Exception e) {
-                                        LogManger.INSTANCE.log("ChatSDK:", "Error parsing block metadata: " + e.getMessage());
+                                    String opponentUserId = conversationDetailsUtil.getOpponentDetails() != null
+                                            ? conversationDetailsUtil.getOpponentDetails().getUserId() : null;
+                                    String currentUserId = IsometrikChatSdk.getInstance().getUserSession().getUserId();
+                                    Boolean blockByOpponentUser = BlockStatusUtil.resolveBlockedByOpponent(
+                                            conversationDetailsUtil.getMetaData(), null, conversationId,
+                                            opponentUserId, currentUserId, true, "ConversationDetails");
+                                    if (blockByOpponentUser != null) {
+                                        BlockStatusUtil.log("ConversationDetails",
+                                            "applying blockedStatus=" + blockByOpponentUser
+                                                + " (was opponentUserBlockedMe=" + opponentUserBlockedMe + ")");
+                                        opponentUserBlockedMe = blockByOpponentUser;
+                                        conversationMessagesView.blockedStatus(blockByOpponentUser);
+                                    } else {
+                                        BlockStatusUtil.log("ConversationDetails",
+                                            "metadata inconclusive, keeping opponentUserBlockedMe=" + opponentUserBlockedMe);
                                     }
-                                    conversationMessagesView.blockedStatus(blockByOpponentUser);
+                                    conversationMessagesView.onMessagingStatusChanged(true);
                                 } else {
+                                    opponentUserBlockedMe = false;
                                     conversationMessagesView.blockedStatus(false);
                                 }
                             } else {
@@ -2210,10 +2248,14 @@ public class ConversationMessagesPresenter implements ConversationMessagesContra
                                 .setUserToken(userToken)
                                 .build(), (var1, var2) -> {
                             if (var1 != null) {
-
-//                                if (var1.isMessagingEnabled()) {
-                                    conversationMessagesView.onMessagingStatusChanged(!var1.isMessagingEnabled());
-//                                }
+                                BlockStatusUtil.log("checkIfMessagingEnabled",
+                                    "messagingEnabled=" + var1.isMessagingEnabled()
+                                        + " opponentUserBlockedMe=" + opponentUserBlockedMe);
+                                if (!var1.isMessagingEnabled()) {
+                                    conversationMessagesView.onMessagingStatusChanged(true);
+                                } else {
+                                    conversationMessagesView.onMessagingStatusChanged(false);
+                                }
                             } else {
                                 conversationMessagesView.onError(var2.getErrorMessage());
                             }
@@ -2223,6 +2265,15 @@ public class ConversationMessagesPresenter implements ConversationMessagesContra
     @Override
     public boolean isPrivateOneToOne() {
         return isPrivateOneToOne;
+    }
+
+    private boolean shouldHideBlockStatusMessage(Message message) {
+        String action = message.getAction();
+        if (!"userBlockConversation".equals(action) && !"userUnblockConversation".equals(action)) {
+            return false;
+        }
+        String currentUserName = IsometrikChatSdk.getInstance().getUserSession().getUserName();
+        return message.getOpponentName() != null && message.getOpponentName().equals(currentUserName);
     }
 
     private void updateLastReadInConversation() {
@@ -2337,12 +2388,20 @@ public class ConversationMessagesPresenter implements ConversationMessagesContra
     }
 
     @Override
+    public void setOpponentUserBlockedMe(boolean opponentUserBlockedMe) {
+        this.opponentUserBlockedMe = opponentUserBlockedMe;
+    }
+
+    @Override
     public void blockUser(String userId, boolean isBlocked, String personalUserId) {
         isometrik.getRemoteUseCases()
                 .getUserUseCases()
                 .blockUser(
                         new BlockUserQuery.Builder().setUserToken(userToken).setOpponentId(userId).build(), (var1, var2) -> {
                             if (var1 != null) {
+                                opponentUserBlockedMe = false;
+                                BlockStateCache.setBlockedByOpponentForConversation(conversationId, userId, false);
+                                conversationMessagesView.blockedStatus(false);
                                 conversationMessagesView.onUserBlocked();
                             } else {
                                 conversationMessagesView.onError(var2.getErrorMessage());
@@ -2358,6 +2417,9 @@ public class ConversationMessagesPresenter implements ConversationMessagesContra
                         .setOpponentId(userId)
                         .build(), (var1, var2) -> {
                     if (var1 != null) {
+                        opponentUserBlockedMe = false;
+                        BlockStateCache.clearConversation(conversationId, userId);
+                        conversationMessagesView.blockedStatus(false);
                         conversationMessagesView.onUserUnBlocked();
                     } else {
                         conversationMessagesView.onError(var2.getErrorMessage());

--- a/isometrik-chat/src/main/java/io/isometrik/ui/messages/chat/common/ChatConfig.kt
+++ b/isometrik-chat/src/main/java/io/isometrik/ui/messages/chat/common/ChatConfig.kt
@@ -41,6 +41,12 @@ object ChatConfig {
     var hideViewSocialProfileOption: Boolean = true
 
     /**
+     * When true, hides the Block option in chat menu while the opponent has blocked the current user.
+     * Set to false to allow block-back from the blocked user's side.
+     */
+    var hideBlockOptionWhenBlockedByOpponent: Boolean = true
+
+    /**
      * When true, conversation messages and latest data are refreshed when the user returns
      * from background (e.g. app was in background and user comes back to this screen).
      * Default is false.

--- a/isometrik-chat/src/main/java/io/isometrik/ui/messages/chat/utils/messageutils/ConversationAttachmentMessageUtil.java
+++ b/isometrik-chat/src/main/java/io/isometrik/ui/messages/chat/utils/messageutils/ConversationAttachmentMessageUtil.java
@@ -17,6 +17,9 @@ import io.isometrik.ui.messages.tag.util.ParseMentionedUsersFromFetchMessagesRes
 import io.isometrik.chat.utils.TagUserUtil;
 import io.isometrik.chat.utils.FileUtils;
 
+import com.google.gson.Gson;
+
+import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -599,16 +602,11 @@ public class ConversationAttachmentMessageUtil {
                         messagesModel.setInitiatorImageUrl(message.getInitiatorProfileImageUrl());
                         messagesModel.setAction(message.getAction());
 
-                        // Parse call-related fields from metadata
+                        // Parse call-related fields: API may send callDurations/missedByMembers at message root or inside metaData
+                        setCallDurationsAndMissedByMembers(message, messagesModel);
                         JSONObject metadata = message.getMetaData();
                         if (metadata != null) {
                             try {
-                                if (metadata.has("missedByMembers")) {
-                                    messagesModel.setMissedByMembers(metadata.getJSONArray("missedByMembers"));
-                                }
-                                if (metadata.has("callDurations")) {
-                                    messagesModel.setCallDurations(metadata.getJSONArray("callDurations"));
-                                }
                                 if (metadata.has("audioOnly")) {
                                     messagesModel.setAudioOnly(metadata.getBoolean("audioOnly"));
                                 }
@@ -670,16 +668,11 @@ public class ConversationAttachmentMessageUtil {
                     messagesModel.setInitiatorImageUrl(message.getInitiatorProfileImageUrl());
                     messagesModel.setAction(message.getAction());
 
-                    // Parse call-related fields from metadata
+                    // Parse call-related fields: API may send callDurations/missedByMembers at message root or inside metaData
+                    setCallDurationsAndMissedByMembers(message, messagesModel);
                     JSONObject metadata = message.getMetaData();
                     if (metadata != null) {
                         try {
-                            if (metadata.has("missedByMembers")) {
-                                messagesModel.setMissedByMembers(metadata.getJSONArray("missedByMembers"));
-                            }
-                            if (metadata.has("callDurations")) {
-                                messagesModel.setCallDurations(metadata.getJSONArray("callDurations"));
-                            }
                             if (metadata.has("audioOnly")) {
                                 messagesModel.setAudioOnly(metadata.getBoolean("audioOnly"));
                             }
@@ -737,5 +730,35 @@ public class ConversationAttachmentMessageUtil {
             }
         }
         return messagesModel;
+    }
+
+    /**
+     * Sets callDurations and missedByMembers on the model from message root or metaData.
+     * Fetch messages API returns these at message root; realtime may send them in metaData.
+     */
+    private static void setCallDurationsAndMissedByMembers(Message message, MessagesModel messagesModel) {
+        try {
+            // Prefer top-level (fetch messages API)
+            Object callDurationsObj = message.getCallDurations();
+            if (callDurationsObj != null) {
+                messagesModel.setCallDurations(new JSONArray(new Gson().toJson(callDurationsObj)));
+            } else {
+                JSONObject metadata = message.getMetaData();
+                if (metadata != null && metadata.has("callDurations")) {
+                    messagesModel.setCallDurations(metadata.getJSONArray("callDurations"));
+                }
+            }
+            Object missedByMembersObj = message.getMissedByMembers();
+            if (missedByMembersObj != null) {
+                messagesModel.setMissedByMembers(new JSONArray(new Gson().toJson(missedByMembersObj)));
+            } else {
+                JSONObject metadata = message.getMetaData();
+                if (metadata != null && metadata.has("missedByMembers")) {
+                    messagesModel.setMissedByMembers(metadata.getJSONArray("missedByMembers"));
+                }
+            }
+        } catch (JSONException e) {
+            LogManger.INSTANCE.log("ChatSDK:", "Error parsing callDurations/missedByMembers: " + e.getMessage());
+        }
     }
 }

--- a/isometrik-chat/src/main/res/layout/ism_dialog_block_user.xml
+++ b/isometrik-chat/src/main/res/layout/ism_dialog_block_user.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="@color/ism_white"
+    android:gravity="center_horizontal"
+    android:orientation="vertical"
+    android:paddingStart="@dimen/ism_dp_24"
+    android:paddingTop="@dimen/ism_dp_24"
+    android:paddingEnd="@dimen/ism_dp_24"
+    android:paddingBottom="@dimen/ism_dp_8">
+
+    <androidx.appcompat.widget.AppCompatImageView
+        android:layout_width="@dimen/ism_dp_48"
+        android:layout_height="@dimen/ism_dp_48"
+        app:srcCompat="@drawable/ism_ic_block_user" />
+
+    <androidx.appcompat.widget.AppCompatTextView
+        android:id="@+id/tvBlockDialogTitle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/ism_dp_16"
+        android:gravity="center"
+        android:textColor="@color/ism_black"
+        android:textSize="@dimen/ism_sp_18"
+        android:textStyle="bold" />
+
+    <androidx.appcompat.widget.AppCompatTextView
+        android:id="@+id/tvBlockDialogMessage"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/ism_dp_12"
+        android:gravity="center"
+        android:lineSpacingExtra="@dimen/ism_dp_4"
+        android:text="@string/ism_block_user_dialog_message"
+        android:textColor="@color/ism_conversation_details_grey"
+        android:textSize="@dimen/ism_sp_14" />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/ism_dp_24"
+        android:gravity="end"
+        android:orientation="horizontal">
+
+        <androidx.appcompat.widget.AppCompatTextView
+            android:id="@+id/tvCancel"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:padding="@dimen/ism_dp_12"
+            android:text="@string/ism_cancel"
+            android:textAllCaps="true"
+            android:textColor="@color/ism_theme_base"
+            android:textStyle="bold" />
+
+        <androidx.appcompat.widget.AppCompatTextView
+            android:id="@+id/tvBlock"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:padding="@dimen/ism_dp_12"
+            android:text="@string/ism_block"
+            android:textAllCaps="true"
+            android:textColor="@color/ism_theme_base"
+            android:textStyle="bold" />
+    </LinearLayout>
+</LinearLayout>

--- a/isometrik-chat/src/main/res/values/strings.xml
+++ b/isometrik-chat/src/main/res/values/strings.xml
@@ -584,6 +584,8 @@
     <string name="ism_fetching_blocked_users">Fetching blocked users</string>
     <string name="ism_fetching_non_blocked_users">Fetching non-blocked users</string>
     <string name="ism_block_user_alert_message">Once blocked you will not be able to send message to or create conversations with user.</string>
+    <string name="ism_block_user_dialog_title">Block %1$s?</string>
+    <string name="ism_block_user_dialog_message">This person won\'t be able to message or call you. They won\'t know you blocked them.</string>
     <string name="ism_unblock_user_alert_message">Once unblocked you can send message to or create conversations with user.</string>
 
     <!--  Notifications-->


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
Fixes the block/unblock feature to correctly handle opponent blocking status, ensuring that the UI reflects when the opponent has blocked the current user and when the current user has blocked the opponent. It also introduces a new configuration option to hide the block option in the chat menu when the opponent has blocked the user, preventing unintended block-back actions. Additionally, the code updates message handling to account for opponent block status, disables messaging UI elements accordingly, and manages block state persistence across the app.
<!-- kody-pr-summary:end -->