### PR TITLE
- Fix: Chat reaction

### DIFF
--- a/isometrik-chat/src/main/java/io/isometrik/ui/messages/reaction/add/AddReactionContract.java
+++ b/isometrik-chat/src/main/java/io/isometrik/ui/messages/reaction/add/AddReactionContract.java
@@ -38,6 +38,14 @@ public interface AddReactionContract {
     void onReactionAddedSuccessfully(String messageId, ReactionModel reactionModel);
 
     /**
+     * On reaction removed successfully.
+     *
+     * @param messageId the message id
+     * @param reactionModel the reaction model
+     */
+    void onReactionRemovedSuccessfully(String messageId, ReactionModel reactionModel);
+
+    /**
      * On error.
      *
      * @param errorMessage the error message to be shown in the toast for details of the failed

--- a/isometrik-chat/src/main/java/io/isometrik/ui/messages/reaction/add/AddReactionFragment.java
+++ b/isometrik-chat/src/main/java/io/isometrik/ui/messages/reaction/add/AddReactionFragment.java
@@ -62,6 +62,7 @@ public class AddReactionFragment extends BottomSheetDialogFragment
         new LinearLayoutManager(activity, RecyclerView.HORIZONTAL, false));
     reactions = new ArrayList<>();
     reactions.addAll(ReactionRepository.getReactions());
+    selectedReactionPosition = 0;
     AddReactionAdapter addReactionAdapter = new AddReactionAdapter(activity, reactions);
     ismBottomsheetReactionBinding.rvReactions.setAdapter(addReactionAdapter);
 
@@ -158,6 +159,16 @@ public class AddReactionFragment extends BottomSheetDialogFragment
     }
   }
 
+  @Override
+  public void onReactionRemovedSuccessfully(String messageId, ReactionModel reactionModel) {
+    hideProgressDialog();
+    messageActionCallback.updateMessageReaction(messageId, reactionModel, false);
+    try {
+      dismiss();
+    } catch (Exception ignore) {
+    }
+  }
+
   private void showProgressDialog(String message) {
     if (activity != null) {
       alertDialog = alertProgress.getProgressDialog(activity, message);
@@ -182,5 +193,6 @@ public class AddReactionFragment extends BottomSheetDialogFragment
     this.messageId = messageId;
     this.conversationId = conversationId;
     this.messageActionCallback = messageActionCallback;
+    this.selectedReactionPosition = 0;
   }
 }

--- a/isometrik-chat/src/main/java/io/isometrik/ui/messages/reaction/add/AddReactionPresenter.java
+++ b/isometrik-chat/src/main/java/io/isometrik/ui/messages/reaction/add/AddReactionPresenter.java
@@ -2,8 +2,12 @@ package io.isometrik.ui.messages.reaction.add;
 
 import io.isometrik.chat.Isometrik;
 import io.isometrik.chat.builder.reaction.AddReactionQuery;
+import io.isometrik.chat.builder.reaction.FetchReactionsQuery;
+import io.isometrik.chat.builder.reaction.RemoveReactionQuery;
+import io.isometrik.chat.response.reaction.FetchReactionsResult;
 import io.isometrik.ui.IsometrikChatSdk;
 import io.isometrik.ui.messages.reaction.util.ReactionUtil;
+import io.isometrik.chat.utils.Constants;
 
 /**
  * The presenter to add a reaction of particular type on a message by logged in user.
@@ -32,21 +36,90 @@ public class AddReactionPresenter implements AddReactionContract.Presenter {
 
   @Override
   public void addReaction(String conversationId, String messageId, String reactionType) {
-    isometrik.getRemoteUseCases().getReactionUseCases().addReaction(new AddReactionQuery.Builder().setConversationId(conversationId)
-        .setUserToken(userToken)
-        .setMessageId(messageId)
-        .setReactionType(reactionType)
-        .build(), (var1, var2) -> {
-      if (var1 != null) {
-        if (addReactionView != null) {
-          ReactionModel reactionModel =
-              ReactionUtil.parseAddOrRemoveReactionEvent(reactionType, var1.getReactionsCount());
+    isometrik.getRemoteUseCases().getReactionUseCases().fetchReactions(
+        new FetchReactionsQuery.Builder().setLimit(Constants.USERS_PAGE_SIZE)
+            .setSkip(0)
+            .setConversationId(conversationId)
+            .setMessageId(messageId)
+            .setReactionType(reactionType)
+            .setUserToken(userToken)
+            .build(), (fetchResult, fetchError) -> {
+          if (fetchResult != null) {
+            if (hasUserAlreadyReacted(fetchResult)) {
+              removeReaction(conversationId, messageId, reactionType);
+            } else {
+              requestAddReaction(conversationId, messageId, reactionType);
+            }
+          } else if (fetchError != null && fetchError.getHttpResponseCode() == 404
+              && fetchError.getRemoteErrorCode() == 2) {
+            requestAddReaction(conversationId, messageId, reactionType);
+          } else if (addReactionView != null) {
+            addReactionView.onError(fetchError != null ? fetchError.getErrorMessage() : null);
+          }
+        });
+  }
 
-          addReactionView.onReactionAddedSuccessfully(messageId, reactionModel);
-        }
-      } else {
-        if (addReactionView != null) addReactionView.onError(var2.getErrorMessage());
+  private boolean hasUserAlreadyReacted(FetchReactionsResult fetchResult) {
+    if (fetchResult.getUserReactions() == null || fetchResult.getUserReactions().isEmpty()) {
+      return false;
+    }
+    String userId = IsometrikChatSdk.getInstance().getUserSession().getUserId();
+    for (FetchReactionsResult.UserReaction userReaction : fetchResult.getUserReactions()) {
+      if (userId.equals(userReaction.getUserId())) {
+        return true;
       }
-    });
+    }
+    return false;
+  }
+
+  private void requestAddReaction(String conversationId, String messageId, String reactionType) {
+    isometrik.getRemoteUseCases().getReactionUseCases().addReaction(
+        new AddReactionQuery.Builder().setConversationId(conversationId)
+            .setUserToken(userToken)
+            .setMessageId(messageId)
+            .setReactionType(reactionType)
+            .build(), (addResult, addError) -> {
+          if (addResult != null) {
+            if (addReactionView != null) {
+              ReactionModel reactionModel =
+                  ReactionUtil.parseAddOrRemoveReactionEvent(reactionType,
+                      addResult.getReactionsCount());
+              addReactionView.onReactionAddedSuccessfully(messageId, reactionModel);
+            }
+          } else if (addError != null && isDuplicateReactionError(addError)) {
+            removeReaction(conversationId, messageId, reactionType);
+          } else if (addReactionView != null) {
+            addReactionView.onError(addError != null ? addError.getErrorMessage() : null);
+          }
+        });
+  }
+
+  private void removeReaction(String conversationId, String messageId, String reactionType) {
+    isometrik.getRemoteUseCases().getReactionUseCases().removeReaction(
+        new RemoveReactionQuery.Builder().setConversationId(conversationId)
+            .setUserToken(userToken)
+            .setMessageId(messageId)
+            .setReactionType(reactionType)
+            .build(), (removeResult, removeError) -> {
+          if (removeResult != null) {
+            if (addReactionView != null) {
+              ReactionModel reactionModel =
+                  ReactionUtil.parseAddOrRemoveReactionEvent(reactionType,
+                      removeResult.getReactionsCount());
+              addReactionView.onReactionRemovedSuccessfully(messageId, reactionModel);
+            }
+          } else if (addReactionView != null) {
+            addReactionView.onError(removeError != null ? removeError.getErrorMessage() : null);
+          }
+        });
+  }
+
+  private boolean isDuplicateReactionError(io.isometrik.chat.response.error.IsometrikError error) {
+    int httpCode = error.getHttpResponseCode();
+    if (httpCode == 400 || httpCode == 409) {
+      return true;
+    }
+    String errorMessage = error.getErrorMessage();
+    return errorMessage != null && errorMessage.toLowerCase().contains("already");
   }
 }


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request introduces functionality to handle the removal of reactions in the chat interface. It adds a new callback method to the view interface to notify when a reaction has been successfully removed. The fragment is updated to initialize the selected reaction position and to handle the removal process, including dismissing the reaction selection UI upon success. The presenter is enhanced to check if the user has already reacted to a message and, if so, to send a request to remove that reaction. It also manages the logic for adding or removing reactions based on the current reaction state, including handling specific error cases such as duplicate reactions. Overall, these changes enable users to remove their reactions from messages, complementing the existing reaction addition functionality.
<!-- kody-pr-summary:end -->